### PR TITLE
96.精读《useEffect%20完全指南》-- 修正錯誤依賴

### DIFF
--- a/前沿技术/96.精读《useEffect 完全指南》.md
+++ b/前沿技术/96.精读《useEffect 完全指南》.md
@@ -422,7 +422,7 @@ function Article({ id }) {
     return () => {
       didCancel = true;
     };
-  }, [API.fetchArticle]);
+  }, [id]);
 
   // ...
 }


### PR DESCRIPTION
https://github.com/ascoders/weekly/blob/master/%E5%89%8D%E6%B2%BF%E6%8A%80%E6%9C%AF/96.%E7%B2%BE%E8%AF%BB%E3%80%8AuseEffect%20%E5%AE%8C%E5%85%A8%E6%8C%87%E5%8D%97%E3%80%8B.md#%E6%9B%B4%E6%9B%B4%E6%9B%B4%E5%86%85%E8%81%9A

副作用發生於 `id` 產生變化時，並非 `API.fetchArticle`。

原文：

![2021-05-07 12-05-32(1)](https://user-images.githubusercontent.com/87983/117396512-b1b84f00-af2c-11eb-9dc7-805e7435ec91.jpg)
